### PR TITLE
Optimized DiamondSquareGPU minimizing memory access.

### DIFF
--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -121,6 +121,169 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!43 &66701469
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Mesh
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 0
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 0
+    localAABB:
+      m_Center: {x: 0, y: 0, z: 0}
+      m_Extent: {x: 0, y: 0, z: 0}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 0
+  m_KeepIndices: 0
+  m_IndexFormat: 1
+  m_IndexBuffer: 
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 0
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 0
+    _typelessdata: 
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    offset: 0
+    size: 0
+    path: 
 --- !u!1 &705507993
 GameObject:
   m_ObjectHideFlags: 0
@@ -336,7 +499,7 @@ MeshFilter:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 740622402}
-  m_Mesh: {fileID: 2013374336}
+  m_Mesh: {fileID: 66701469}
 --- !u!1 &963194225
 GameObject:
   m_ObjectHideFlags: 0
@@ -541,166 +704,3 @@ MonoBehaviour:
   factor: 0.5
   talusFactor: 4
   iterations: 200
---- !u!43 &2013374336
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Mesh
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 0
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 0
-    localAABB:
-      m_Center: {x: 0, y: 0, z: 0}
-      m_Extent: {x: 0, y: 0, z: 0}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 0
-  m_KeepIndices: 0
-  m_IndexFormat: 1
-  m_IndexBuffer: 
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 0
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 0
-    _typelessdata: 
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 0, y: 0, z: 0}
-    m_Extent: {x: 0, y: 0, z: 0}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    offset: 0
-    size: 0
-    path: 

--- a/Assets/Scripts/Generation/Terrain/Procedural/GPU/DiamondSquareGPU.cs
+++ b/Assets/Scripts/Generation/Terrain/Procedural/GPU/DiamondSquareGPU.cs
@@ -8,6 +8,8 @@ namespace Generation.Terrain.Procedural.GPU
         public float Height { get; set; }
         public ComputeShader Shader { get; set; }
 
+        private ComputeBuffer buffer;
+
         public DiamondSquareGPU()
         {
             Resolution = 1024;
@@ -37,17 +39,29 @@ namespace Generation.Terrain.Procedural.GPU
 
             int i = 0;
             int numthreads = 0;
+
+            int kernelId = InitComputeShader(heightmap);
+
+            int totalThreadsUsed = 0;
             while (squareSize > 1)
             {
                 // Calculates the number of calls to DiamondSquare per iterations. Each call represents a new gpu thread
                 numthreads = i > 0 ? (i * 2) : 1;
                 i = numthreads;
 
-                RunOnGPU(heightmap, squareSize, numthreads);
+                RunOnGPU(kernelId, squareSize, numthreads);
 
                 squareSize /= 2;
                 Height *= 0.5f;
+
+                // For debug purposes only
+                totalThreadsUsed += numthreads;
             }
+
+            FinishComputeShader(heightmap);
+
+            // For debug purposes only
+            Debug.Log($"Number of threads used: {totalThreadsUsed}.");
         }
 
         private void RandomizeCorners(float[,] heightmap)
@@ -58,29 +72,37 @@ namespace Generation.Terrain.Procedural.GPU
             heightmap[Resolution, Resolution] = RandomValue() * Height;
         }
 
-        private void RunOnGPU(float[,] heightMap, float squareSize, int numthreads)
+        private int InitComputeShader(float[,] heightmap)
         {
             // Creates a read/writable buffer that contains the heightmap data and sends it to the GPU.
             // The buffer needs to be the same length as the heightmap, and each element in the heightmap is a single float which is 4 bytes long.
-            ComputeBuffer buffer = new ComputeBuffer(heightMap.Length, 4);
+            buffer = new ComputeBuffer(heightmap.Length, 4);
 
             // Set the initial data to be held in the buffer as the pre-generated heightmap
-            buffer.SetData(heightMap);
+            buffer.SetData(heightmap);
 
             int kernelId = Shader.FindKernel("CSMain");     // Gets the id of the main kernel of the shader
 
             Shader.SetBuffer(kernelId, "terrain", buffer);  // Set the terrain buffer
-
-            // Initializes the parameters needed for the shader
             Shader.SetInt("width", Resolution);
+
+            return kernelId;
+        }
+
+        private void RunOnGPU(int kernelId, float squareSize, int numthreads)
+        {
+            // Initializes the parameters needed for the shader
             Shader.SetFloat("height", Height);
             Shader.SetFloat("squareSize", squareSize);
             Shader.SetInt("externalSeed", new System.Random().Next());
 
             // Executes the compute shader on the GPU
             Shader.Dispatch(kernelId, numthreads, numthreads, 1);
+        }
 
-            buffer.GetData(heightMap);          // Receive the updated heightmap data from the buffer
+        private void FinishComputeShader(float[,] heightmap)
+        {
+            buffer.GetData(heightmap);          // Receive the updated heightmap data from the buffer
             buffer.Dispose();                   // Dispose the buffer 
         }
 

--- a/Assets/Scripts/Unity/Components/DiamondSquareComponent.cs
+++ b/Assets/Scripts/Unity/Components/DiamondSquareComponent.cs
@@ -1,5 +1,6 @@
 ﻿using Generation.Terrain.Procedural.GPU;
 using Generation.Terrain.Procedural;
+using System.Diagnostics;
 using UnityEngine;
 
 namespace Unity.Components
@@ -22,7 +23,15 @@ namespace Unity.Components
             if(!useGPU) {
                 diamondSquare.Resolution = base.meshGenerator.resolution;
                 diamondSquare.Height = height;
+
+                Stopwatch stopWatch = new Stopwatch();
+                stopWatch.Start();
+
                 diamondSquare.Apply(heightmap);
+
+                stopWatch.Stop ();
+                UnityEngine.Debug.Log($"DiamondSquare on CPU with {diamondSquare.Resolution}x{diamondSquare.Resolution} vertices took {stopWatch.Elapsed.Milliseconds}ms.");
+                stopWatch.Reset ();
             }
             else
             {
@@ -30,7 +39,14 @@ namespace Unity.Components
                 diamondSquareGPU.Height = height;
                 diamondSquareGPU.Shader = shader;
 
+                Stopwatch stopWatch = new Stopwatch();
+                stopWatch.Start();
+
                 diamondSquareGPU.Apply(heightmap);
+            
+                stopWatch.Stop ();
+                UnityEngine.Debug.Log($"DiamondSquare on GPU with {diamondSquareGPU.Resolution}x{diamondSquareGPU.Resolution} vertices took {stopWatch.Elapsed.Milliseconds}ms.");
+                stopWatch.Reset ();
             }
             
             base.UpdateTerrainHeight(heightmap);


### PR DESCRIPTION
The Diamond-Square algorithm in GPU was sending and retrieving the data buffer used by the shader at each iteration. This was unnecessary as the buffer could be sent only once at the beginning and retrieved only after all iterations.

When running the algorithm on an **NVIDIA MX130 (2GB)**, the algorithm was taking an average of **160 milliseconds**. After this small change the execution time of the algorithm dropped to **50 milliseconds**.