### PR TITLE
Added implementation of Thermal Erosion running on GPU with Compute Shader.

### DIFF
--- a/Assets/Editor/DiamondSquareEditor.cs
+++ b/Assets/Editor/DiamondSquareEditor.cs
@@ -6,13 +6,11 @@ using UnityEngine;
 [CanEditMultipleObjects]
 public class DiamondSquareEditor : Editor
 {
-    private SerializedProperty resolution;
     private SerializedProperty shader;
     private SerializedProperty useGPU;
 
     void OnEnable()
     {
-        resolution = serializedObject.FindProperty("resolution");
         shader = serializedObject.FindProperty("shader");
         useGPU = serializedObject.FindProperty("useGPU");
     }
@@ -22,7 +20,6 @@ public class DiamondSquareEditor : Editor
         serializedObject.Update();
         DiamondSquareComponent component = (DiamondSquareComponent)target;
 
-        EditorGUILayout.PropertyField(resolution);
         EditorGUILayout.PropertyField(shader);
         EditorGUILayout.PropertyField(useGPU);
         

--- a/Assets/Editor/ThermalErosionEditor.cs
+++ b/Assets/Editor/ThermalErosionEditor.cs
@@ -9,12 +9,16 @@ public class ThermalErosionEditor : Editor
     private SerializedProperty talusFactor;
     private SerializedProperty factor;
     private SerializedProperty iterations;
+    private SerializedProperty shader;
+    private SerializedProperty useGPU;
     
     void OnEnable()
     {
         factor = serializedObject.FindProperty("talusFactor");
         talusFactor = serializedObject.FindProperty("factor");
         iterations = serializedObject.FindProperty("iterations");
+        shader = serializedObject.FindProperty("shader");
+        useGPU = serializedObject.FindProperty("useGPU");
     }
 
     public override void OnInspectorGUI()
@@ -25,6 +29,8 @@ public class ThermalErosionEditor : Editor
         EditorGUILayout.PropertyField(talusFactor);
         EditorGUILayout.PropertyField(factor);
         EditorGUILayout.PropertyField(iterations);
+        EditorGUILayout.PropertyField(shader);
+        EditorGUILayout.PropertyField(useGPU);
         
         if (GUILayout.Button("Apply"))
             component.UpdateComponent();

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -121,7 +121,7 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!43 &542985740
+--- !u!43 &120946947
 Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -499,7 +499,7 @@ MeshFilter:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 740622402}
-  m_Mesh: {fileID: 542985740}
+  m_Mesh: {fileID: 120946947}
 --- !u!1 &963194225
 GameObject:
   m_ObjectHideFlags: 0
@@ -703,3 +703,5 @@ MonoBehaviour:
   factor: 0.5
   talusFactor: 6
   iterations: 10
+  shader: {fileID: 7200000, guid: d6962c6e1071c4145a3d5bfa612d40a8, type: 3}
+  useGPU: 0

--- a/Assets/Scripts/Generation/Terrain/Physics/ThermalErosion.cs
+++ b/Assets/Scripts/Generation/Terrain/Physics/ThermalErosion.cs
@@ -51,7 +51,7 @@ namespace Generation.Terrain.Physics.Erosion
                     float maxHeightDiff = 0;            // Maior diferença encontrada entre os vizinhos.
                     float sumExceededDiffs = 0;         // Soma das diferenças que ultrapassam o limite talus.
 
-                    List<Coords> neighbors = Generation.Terrain.Utils.Neighborhood.VonNeumann(new Coords(x, y), maxX, maxY);
+                    List<Coords> neighbors = Generation.Terrain.Utils.Neighborhood.Moore(new Coords(x, y), maxX, maxY);
 
                     // Primeiro loop não realiza nenhuma alteração no relevo.
                     // Percorre os vizinhos calculando qual a maior diferença de altura entre todos

--- a/Assets/Scripts/Generation/Terrain/Physics/ThermalErosion.cs
+++ b/Assets/Scripts/Generation/Terrain/Physics/ThermalErosion.cs
@@ -20,10 +20,10 @@ namespace Generation.Terrain.Physics.Erosion
         /// Applies the DryErosion algorithm multiple times to get more realistic results.
         /// The amount of repetitions is controlled by the 'iterations' variable.
         /// </summary>
-        public void Erode(float[,] matrix, float talus = 1, float factor = 0.5f, int iterations = 500)
+        public virtual void Erode(float[,] heightmap, float talus = 1, float factor = 0.5f, int iterations = 500)
         {
             for (int i = 0; i < iterations; i++)
-                DryErosion(matrix, talus, factor);
+                DryErosion(heightmap, talus, factor);
         }
 
         /// <summary>
@@ -37,13 +37,13 @@ namespace Generation.Terrain.Physics.Erosion
         /// e talus representa a diferença máxima permitida.
         /// Olsen (2004, p. 6) sugere que o valor ideal para factor é 0,5.
         /// </summary>
-        /// <param name="matrix">Mapa de altura do relevo.</param>
+        /// <param name="heightmap">Mapa de altura do relevo.</param>
         /// <param name="talus">Diferença de altura máxima permitida.</param>
         /// <param name="factor">Fator limitante de movimentação.</param>
-        public void DryErosion(float[,] matrix, float talus = 1, float factor = 0.5f)
+        private void DryErosion(float[,] heightmap, float talus = 4, float factor = 0.5f)
         {
-            int maxX = matrix.GetLength(0);
-            int maxY = matrix.GetLength(1);
+            int maxX = heightmap.GetLength(0);
+            int maxY = heightmap.GetLength(1);
             for (int x = 0; x < maxX; x++)
             {
                 for (int y = 0; y < maxY; y++)
@@ -58,7 +58,7 @@ namespace Generation.Terrain.Physics.Erosion
                     // e a soma de todas as diferenças de altura que ultrapassam o limite talus.
                     foreach (var neighbor in neighbors)
                     {
-                        float heightDiff = matrix[x, y] - matrix[neighbor.X, neighbor.Y];
+                        float heightDiff = heightmap[x, y] - heightmap[neighbor.X, neighbor.Y];
                         if (heightDiff > maxHeightDiff)
                             maxHeightDiff = heightDiff;
                         if (heightDiff > talus)
@@ -72,7 +72,7 @@ namespace Generation.Terrain.Physics.Erosion
                     // Segundo loop é onde são feitas as alterações.
                     foreach (var neighbor in neighbors)
                     {
-                        float heightDiff = matrix[x, y] - matrix[neighbor.X, neighbor.Y];
+                        float heightDiff = heightmap[x, y] - heightmap[neighbor.X, neighbor.Y];
 
                         // Se a diferença de altura entre a posição atual e algum vizinho for maior que o limite talus,
                         // remove material da posição atual e aplica ao vizinho.
@@ -80,8 +80,8 @@ namespace Generation.Terrain.Physics.Erosion
                         {
                             // Fórmula de distribuição do solo.
                             float sediment = factor * (maxHeightDiff - talus) * (heightDiff / sumExceededDiffs);
-                            matrix[neighbor.X, neighbor.Y] += sediment;
-                            matrix[x, y] -= sediment;
+                            heightmap[neighbor.X, neighbor.Y] += sediment;
+                            heightmap[x, y] -= sediment;
                         }
                     }
                 }

--- a/Assets/Scripts/Generation/Terrain/Physics/ThermalErosionGPU.cs
+++ b/Assets/Scripts/Generation/Terrain/Physics/ThermalErosionGPU.cs
@@ -27,7 +27,7 @@ namespace Generation.Terrain.Physics.Erosion.GPU
             Shader.SetBuffer(kernelId, "heightmap", buffer);    // Set the heightmap buffer
             Shader.SetFloat("talus", talus);
             Shader.SetFloat("factor", factor);
-            Shader.SetFloat("width", heightmap.GetLength(0)-1);
+            Shader.SetInt("width", heightmap.GetLength(0));
 
             return kernelId;
         }

--- a/Assets/Scripts/Generation/Terrain/Physics/ThermalErosionGPU.cs
+++ b/Assets/Scripts/Generation/Terrain/Physics/ThermalErosionGPU.cs
@@ -1,0 +1,56 @@
+﻿using UnityEngine;
+
+namespace Generation.Terrain.Physics.Erosion.GPU
+{
+    public class ThermalErosionGPU : ThermalErosion
+    {
+        public ComputeShader Shader { get; set; }
+
+        private ComputeBuffer buffer;
+        
+        public ThermalErosionGPU(ComputeShader shader) : base()
+        {
+            Shader = shader;
+        }
+
+        private int InitComputeShader(float[,] heightmap, float talus, float factor)
+        {
+            // Creates a read/writable buffer that contains the heightmap data and sends it to the GPU.
+            // The buffer needs to be the same length as the heightmap, and each element in the heightmap is a single float which is 4 bytes long.
+            buffer = new ComputeBuffer(heightmap.Length, 4);
+
+            // Set the initial data to be held in the buffer as the pre-generated heightmap
+            buffer.SetData(heightmap);
+
+            int kernelId = Shader.FindKernel("CSMain");         // Gets the id of the main kernel of the shader
+
+            Shader.SetBuffer(kernelId, "heightmap", buffer);    // Set the heightmap buffer
+            Shader.SetFloat("talus", talus);
+            Shader.SetFloat("factor", factor);
+            Shader.SetFloat("width", heightmap.GetLength(0)-1);
+
+            return kernelId;
+        }
+
+        public override void Erode(float[,] heightmap, float talus = 4, float factor = 0.5f, int iterations = 500)
+        {
+            int kernelId = InitComputeShader(heightmap, talus, factor);
+
+            for (int i = 0; i < iterations; i++)
+                RunComputeShader(kernelId);
+        
+            FinishComputeShader(heightmap);
+        }
+
+        private void RunComputeShader(int kernelId)
+        {
+            Shader.Dispatch(kernelId, 32, 32, 1);
+        }
+
+        private void FinishComputeShader(float[,] heightmap)
+        {
+            buffer.GetData(heightmap);          // Receive the updated heightmap data from the buffer
+            buffer.Dispose();                   // Dispose the buffer 
+        }
+    }
+}

--- a/Assets/Scripts/Generation/Terrain/Physics/ThermalErosionGPU.cs.meta
+++ b/Assets/Scripts/Generation/Terrain/Physics/ThermalErosionGPU.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a811dcf23c4333c45a7ff559ebb8cc80
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Generation/Terrain/Physics/ThermalErosionShader.compute
+++ b/Assets/Scripts/Generation/Terrain/Physics/ThermalErosionShader.compute
@@ -1,0 +1,46 @@
+﻿#pragma kernel CSMain
+
+RWStructuredBuffer<float> heightmap;
+
+float talus;
+float factor;
+uint width;
+
+// all neighbours positions 
+uint up;
+uint down;
+uint left;
+uint right;
+uint leftUp;
+uint rightUp;
+uint leftDown;
+uint rightDown;
+
+void GetNeighbors(uint currentPosition)
+{
+	up = currentPosition - width;
+	down = currentPosition + width;
+	left = currentPosition - 1;
+	right = currentPosition + 1;
+	leftUp = (currentPosition - 1) - width;
+	rightUp = (currentPosition + 1) - width;
+	leftDown = (currentPosition - 1) + width;
+	rightDown = (currentPosition + 1) + width;
+}
+
+void ThermalErosion()
+{
+
+}
+
+[numthreads(32,32,1)]
+void CSMain (uint3 id : SV_DispatchThreadID)
+{
+	int x = id.x;
+	int y = id.y * width;
+	uint currentPosition = x + y;
+
+	GetNeighbors(currentPosition);
+
+	ThermalErosion();
+}

--- a/Assets/Scripts/Generation/Terrain/Physics/ThermalErosionShader.compute
+++ b/Assets/Scripts/Generation/Terrain/Physics/ThermalErosionShader.compute
@@ -9,7 +9,7 @@
 #define LEFT_DOWN 6
 #define RIGHT_DOWN 7
 
-#define NEIGHBORHOOD_SIZE 4
+#define NEIGHBORHOOD_SIZE 8
 
 RWStructuredBuffer<float> heightmap;
 
@@ -19,7 +19,6 @@ uint width;
 
 uint currentPosition;
 
-// stores position of all neighbors 
 uint neighbors[NEIGHBORHOOD_SIZE];
 
 void GetNeighbors()
@@ -28,10 +27,10 @@ void GetNeighbors()
 	neighbors[DOWN] = currentPosition + width;
 	neighbors[LEFT] = currentPosition - 1;
 	neighbors[RIGHT] = currentPosition + 1;
-	// neighbors[LEFT_UP] = (currentPosition - 1) - width;
-	// neighbors[RIGHT_UP] = (currentPosition + 1) - width;
-	// neighbors[LEFT_DOWN] = (currentPosition - 1) + width;
-	// neighbors[RIGHT_DOWN] = (currentPosition + 1) + width;
+	neighbors[LEFT_UP] = (currentPosition - 1) - width;
+	neighbors[RIGHT_UP] = (currentPosition + 1) - width;
+	neighbors[LEFT_DOWN] = (currentPosition - 1) + width;
+	neighbors[RIGHT_DOWN] = (currentPosition + 1) + width;
 }
 
 int isValidPosition(uint3 id)

--- a/Assets/Scripts/Generation/Terrain/Physics/ThermalErosionShader.compute
+++ b/Assets/Scripts/Generation/Terrain/Physics/ThermalErosionShader.compute
@@ -1,46 +1,86 @@
 ﻿#pragma kernel CSMain
 
+#define UP 0
+#define DOWN 1
+#define LEFT 2
+#define RIGHT 3
+#define LEFT_UP 4
+#define RIGHT_UP 5
+#define LEFT_DOWN 6
+#define RIGHT_DOWN 7
+
+#define NEIGHBORHOOD_SIZE 4
+
 RWStructuredBuffer<float> heightmap;
 
 float talus;
 float factor;
 uint width;
 
-// all neighbours positions 
-uint up;
-uint down;
-uint left;
-uint right;
-uint leftUp;
-uint rightUp;
-uint leftDown;
-uint rightDown;
+uint currentPosition;
 
-void GetNeighbors(uint currentPosition)
+// stores position of all neighbors 
+uint neighbors[NEIGHBORHOOD_SIZE];
+
+void GetNeighbors()
 {
-	up = currentPosition - width;
-	down = currentPosition + width;
-	left = currentPosition - 1;
-	right = currentPosition + 1;
-	leftUp = (currentPosition - 1) - width;
-	rightUp = (currentPosition + 1) - width;
-	leftDown = (currentPosition - 1) + width;
-	rightDown = (currentPosition + 1) + width;
+	neighbors[UP] = currentPosition - width;
+	neighbors[DOWN] = currentPosition + width;
+	neighbors[LEFT] = currentPosition - 1;
+	neighbors[RIGHT] = currentPosition + 1;
+	// neighbors[LEFT_UP] = (currentPosition - 1) - width;
+	// neighbors[RIGHT_UP] = (currentPosition + 1) - width;
+	// neighbors[LEFT_DOWN] = (currentPosition - 1) + width;
+	// neighbors[RIGHT_DOWN] = (currentPosition + 1) + width;
 }
 
-void ThermalErosion()
+int isValidPosition(uint3 id)
 {
+	return id.x > 1 && id.x < width-1 && 
+			id.y > 1 && id.y < width-1;
+}
 
+void ThermalErosion(uint3 id)
+{
+	float maxHeightDiff = 0;
+	float sumExceededDiffs = 0;
+
+	float heightDiff;
+	for(uint i = 0; i < NEIGHBORHOOD_SIZE; i++)
+	{
+		heightDiff = heightmap[currentPosition] - heightmap[neighbors[i]];
+		if (heightDiff > maxHeightDiff)
+			maxHeightDiff = heightDiff;
+		if (heightDiff > talus)
+			sumExceededDiffs += heightDiff;
+	}
+
+	if (sumExceededDiffs == 0)
+		return;
+
+	for(uint j = 0; j < NEIGHBORHOOD_SIZE; j++)
+	{
+		heightDiff = heightmap[currentPosition] - heightmap[neighbors[j]];
+
+		// Se a diferença de altura entre a posição atual e algum vizinho for maior que o limite talus,
+		// remove material da posição atual e aplica ao vizinho.
+		if (heightDiff > talus && isValidPosition(id))
+		{
+			// Fórmula de distribuição do solo.
+			float sediment = factor * (maxHeightDiff - talus) * (heightDiff / sumExceededDiffs);
+			heightmap[neighbors[j]] += sediment;
+			heightmap[currentPosition] -= sediment;
+		}
+	}
 }
 
 [numthreads(32,32,1)]
 void CSMain (uint3 id : SV_DispatchThreadID)
 {
-	int x = id.x;
-	int y = id.y * width;
-	uint currentPosition = x + y;
+	uint x = id.x;
+	uint y = id.y * width;
+	currentPosition = x + y;
 
-	GetNeighbors(currentPosition);
-
-	ThermalErosion();
+	GetNeighbors();
+	ThermalErosion(id);
 }

--- a/Assets/Scripts/Generation/Terrain/Physics/ThermalErosionShader.compute.meta
+++ b/Assets/Scripts/Generation/Terrain/Physics/ThermalErosionShader.compute.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: d6962c6e1071c4145a3d5bfa612d40a8
+timeCreated: 1475141543
+licenseType: Free
+ComputeShaderImporter:
+  currentAPIMask: 4
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Generation/Terrain/Procedural/GPU/DiamondSquareGPU.cs
+++ b/Assets/Scripts/Generation/Terrain/Procedural/GPU/DiamondSquareGPU.cs
@@ -38,7 +38,7 @@ namespace Generation.Terrain.Procedural.GPU
                 numthreads = i > 0 ? (i * 2) : 1;
                 i = numthreads;
 
-                RunOnGPU(kernelId, squareSize, height, numthreads);
+                RunComputeShader(kernelId, squareSize, height, numthreads);
 
                 squareSize /= 2;
                 height *= 0.5f;
@@ -62,15 +62,15 @@ namespace Generation.Terrain.Procedural.GPU
             // Set the initial data to be held in the buffer as the pre-generated heightmap
             buffer.SetData(heightmap);
 
-            int kernelId = Shader.FindKernel("CSMain");     // Gets the id of the main kernel of the shader
+            int kernelId = Shader.FindKernel("CSMain");         // Gets the id of the main kernel of the shader
 
-            Shader.SetBuffer(kernelId, "terrain", buffer);  // Set the terrain buffer
+            Shader.SetBuffer(kernelId, "heightmap", buffer);    // Set the heightmap buffer
             Shader.SetInt("width", Resolution);
 
             return kernelId;
         }
 
-        private void RunOnGPU(int kernelId, float squareSize, float height, int numthreads)
+        private void RunComputeShader(int kernelId, float squareSize, float height, int numthreads)
         {
             // Initializes the parameters needed for the shader
             Shader.SetFloat("height", height);

--- a/Assets/Scripts/Generation/Terrain/Procedural/GPU/DiamondSquareShader.compute
+++ b/Assets/Scripts/Generation/Terrain/Procedural/GPU/DiamondSquareShader.compute
@@ -25,8 +25,7 @@ float normalize(uint x)
 
 float random(uint seed, uint offset)
 {
-	float normalizedRandom = normalize(wang_hash(seed+offset));
-	return normalizedRandom;
+	return normalize(wang_hash(seed+offset));
 }
 
 void DiamondSquareAlgorithm(uint row, uint col, uint size, uint seed)
@@ -52,7 +51,7 @@ void CSMain (uint3 id : SV_DispatchThreadID)
 	uint col = (id.x) * squareSize;
 	uint row = (id.y) * squareSize;
 	
-	uint seed = id.xy + externalSeed;
+	uint seed = id.x + id.y + externalSeed;
 
 	DiamondSquareAlgorithm(row, col, squareSize, seed);
 }

--- a/Assets/Scripts/Generation/Terrain/Procedural/GPU/DiamondSquareShader.compute
+++ b/Assets/Scripts/Generation/Terrain/Procedural/GPU/DiamondSquareShader.compute
@@ -1,6 +1,6 @@
 ﻿#pragma kernel CSMain
 
-RWStructuredBuffer<float> terrain;
+RWStructuredBuffer<float> heightmap;
 
 uint width;
 float height;
@@ -37,13 +37,13 @@ void DiamondSquareAlgorithm(uint row, uint col, uint size, uint seed)
 	uint bottomLeft = (row+size)*(width+1)+col;
 
 	// diamond step
-	terrain[mid] = (terrain[topLeft]+terrain[topLeft+size]+terrain[bottomLeft]+terrain[bottomLeft+size]) * 0.25 + random(seed, mid) * height;
+	heightmap[mid] = (heightmap[topLeft]+heightmap[topLeft+size]+heightmap[bottomLeft]+heightmap[bottomLeft+size]) * 0.25 + random(seed, mid) * height;
 
 	// square step
-	terrain[topLeft+halfSize] = (terrain[topLeft]+terrain[topLeft+size]+terrain[mid]) / 3 + random(seed, topLeft+halfSize) * height;
-	terrain[mid-halfSize] = (terrain[topLeft]+terrain[bottomLeft]+terrain[mid]) / 3 + random(seed, mid-halfSize) * height;
-	terrain[mid+halfSize] = (terrain[topLeft+size]+terrain[bottomLeft+size]+terrain[mid]) / 3 + random(seed, mid+halfSize) * height;
-	terrain[bottomLeft+halfSize] = (terrain[bottomLeft]+terrain[bottomLeft+size]+terrain[mid]) / 3 + random(seed, bottomLeft+halfSize) * height;
+	heightmap[topLeft+halfSize] = (heightmap[topLeft]+heightmap[topLeft+size]+heightmap[mid]) / 3 + random(seed, topLeft+halfSize) * height;
+	heightmap[mid-halfSize] = (heightmap[topLeft]+heightmap[bottomLeft]+heightmap[mid]) / 3 + random(seed, mid-halfSize) * height;
+	heightmap[mid+halfSize] = (heightmap[topLeft+size]+heightmap[bottomLeft+size]+heightmap[mid]) / 3 + random(seed, mid+halfSize) * height;
+	heightmap[bottomLeft+halfSize] = (heightmap[bottomLeft]+heightmap[bottomLeft+size]+heightmap[mid]) / 3 + random(seed, bottomLeft+halfSize) * height;
 }
 
 [numthreads(1,1,1)]

--- a/Assets/Scripts/Unity/Components/DiamondSquareComponent.cs
+++ b/Assets/Scripts/Unity/Components/DiamondSquareComponent.cs
@@ -8,7 +8,6 @@ namespace Unity.Components
     [ExecuteInEditMode]
     public class DiamondSquareComponent : BaseComponent
     {
-        public int resolution;
         public ComputeShader shader;
         public bool useGPU;
 

--- a/Assets/Scripts/Unity/Components/ThermalErosionComponent.cs
+++ b/Assets/Scripts/Unity/Components/ThermalErosionComponent.cs
@@ -1,4 +1,6 @@
 ﻿using Generation.Terrain.Physics.Erosion;
+using Generation.Terrain.Physics.Erosion.GPU;
+using TerrainGeneration.Analytics;
 using UnityEngine;
 
 namespace Unity.Components
@@ -9,17 +11,27 @@ namespace Unity.Components
         public float factor;
         public float talusFactor;
         public int iterations;
+        public ComputeShader shader;
+        public bool useGPU;
 
-        private ThermalErosion thermalErosion = new ThermalErosion();
+        private ThermalErosion thermalErosion;
 
         public override void UpdateComponent()
         {
             float[,] heightmap = GetTerrainHeight();
+            int resolution = base.meshGenerator.resolution;
 
             int N = heightmap.GetLength(0);
             float talus = talusFactor / N;
 
+            if (useGPU)
+                thermalErosion = new ThermalErosionGPU(shader);
+            else
+                thermalErosion = new ThermalErosion();
+
+            TimeLogger.Start(thermalErosion.GetType().Name, resolution);
             thermalErosion.Erode(heightmap, talus, factor, iterations);
+            TimeLogger.RecordSingleTimeInMilliseconds();
 
             UpdateTerrainHeight(heightmap);
         }


### PR DESCRIPTION
- Added file `ThermalErosionShader.compute`, which is a Compute Shader with the GPU logic;
- Added file `ThermalErosionGPU.cs` which extends `ThermalErosion `and is responsible for running the Compute Shader;
- Added call to `ThermalErosionGPU` through `ThermalErosionEditor`;
- Updated `ThermalErosion `neighborhood from Neummann to Moore (eight neighbors).