### PR TITLE
Added simple seed logic for Diamond-Square randomness control.

### DIFF
--- a/Assets/Editor/DiamondSquareEditor.cs
+++ b/Assets/Editor/DiamondSquareEditor.cs
@@ -6,11 +6,13 @@ using UnityEngine;
 [CanEditMultipleObjects]
 public class DiamondSquareEditor : Editor
 {
+    private SerializedProperty seed;
     private SerializedProperty shader;
     private SerializedProperty useGPU;
 
     void OnEnable()
     {
+        seed = serializedObject.FindProperty("seed");
         shader = serializedObject.FindProperty("shader");
         useGPU = serializedObject.FindProperty("useGPU");
     }
@@ -20,6 +22,7 @@ public class DiamondSquareEditor : Editor
         serializedObject.Update();
         DiamondSquareComponent component = (DiamondSquareComponent)target;
 
+        EditorGUILayout.PropertyField(seed);
         EditorGUILayout.PropertyField(shader);
         EditorGUILayout.PropertyField(useGPU);
         

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -124,170 +124,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!43 &105878209
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Mesh
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 0
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 0
-    localAABB:
-      m_Center: {x: 0, y: 0, z: 0}
-      m_Extent: {x: 0, y: 0, z: 0}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 0
-  m_KeepIndices: 0
-  m_IndexFormat: 1
-  m_IndexBuffer: 
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 0
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 0
-    _typelessdata: 
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 0, y: 0, z: 0}
-    m_Extent: {x: 0, y: 0, z: 0}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    serializedVersion: 2
-    offset: 0
-    size: 0
-    path: 
 --- !u!1 &705507993
 GameObject:
   m_ObjectHideFlags: 0
@@ -505,7 +341,7 @@ MeshFilter:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 740622402}
-  m_Mesh: {fileID: 105878209}
+  m_Mesh: {fileID: 2035099036}
 --- !u!1 &963194225
 GameObject:
   m_ObjectHideFlags: 0
@@ -598,11 +434,11 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1756491737}
-  - component: {fileID: 1756491734}
   - component: {fileID: 1756491735}
   - component: {fileID: 1756491739}
-  - component: {fileID: 1756491736}
   - component: {fileID: 1756491738}
+  - component: {fileID: 1756491736}
+  - component: {fileID: 1756491734}
   m_Layer: 0
   m_Name: Scripts
   m_TagString: Untagged
@@ -643,6 +479,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   meshGenerator: {fileID: 740622404}
+  seed: arvore
   shader: {fileID: 7200000, guid: d9528acf6b40c4743a7f2f6c7ed57817, type: 3}
   useGPU: 1
 --- !u!114 &1756491736
@@ -710,3 +547,167 @@ MonoBehaviour:
   iterations: 500
   shader: {fileID: 7200000, guid: d6962c6e1071c4145a3d5bfa612d40a8, type: 3}
   useGPU: 1
+--- !u!43 &2035099036
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Mesh
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 0
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 0
+    localAABB:
+      m_Center: {x: 0, y: 0, z: 0}
+      m_Extent: {x: 0, y: 0, z: 0}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 0
+  m_KeepIndices: 0
+  m_IndexFormat: 1
+  m_IndexBuffer: 
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 0
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 0
+    _typelessdata: 
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 

--- a/Assets/Scripts/Generation/Terrain/Procedural/DiamondSquare.cs
+++ b/Assets/Scripts/Generation/Terrain/Procedural/DiamondSquare.cs
@@ -1,4 +1,5 @@
 ﻿using Generation.Terrain.Utils;
+using System;
 
 namespace Generation.Terrain.Procedural
 {
@@ -6,14 +7,12 @@ namespace Generation.Terrain.Procedural
     {
         public int Resolution { get; set; }
 
-        public DiamondSquare()
-        {
-            Resolution = 1024;
-        }
+        protected Random random;
 
-        public DiamondSquare(int resolution)
+        public DiamondSquare(int resolution, int seed = int.MinValue)
         {
             Resolution = resolution;
+            random = seed > int.MinValue ? new Random(seed) : new Random();
         }
 
         public virtual void Apply(float[,] heightmap)
@@ -75,7 +74,10 @@ namespace Generation.Terrain.Procedural
 
         private float RandomValue(float range = 1.0f)
         {
-            return UnityEngine.Random.Range(-range, range);
+            float max = range;
+            float min = -range;
+            float x = (float)random.NextDouble();
+            return (max - min) * x + min;
         }
     }
 }

--- a/Assets/Scripts/Generation/Terrain/Procedural/GPU/DiamondSquareGPU.cs
+++ b/Assets/Scripts/Generation/Terrain/Procedural/GPU/DiamondSquareGPU.cs
@@ -8,14 +8,8 @@ namespace Generation.Terrain.Procedural.GPU
 
         private ComputeBuffer buffer;
 
-        public DiamondSquareGPU(ComputeShader shader) : base()
-        {
-            Shader = shader;
-        }
-
-        public DiamondSquareGPU(int resolution, ComputeShader shader)
-        {
-            Resolution = resolution;
+        public DiamondSquareGPU(int resolution, ComputeShader shader, int seed = 0)
+            : base(resolution, seed) {
             Shader = shader;
         }
 
@@ -66,6 +60,7 @@ namespace Generation.Terrain.Procedural.GPU
 
             Shader.SetBuffer(kernelId, "heightmap", buffer);    // Set the heightmap buffer
             Shader.SetInt("width", Resolution);
+            Shader.SetInt("externalSeed", random.Next());
 
             return kernelId;
         }
@@ -75,7 +70,6 @@ namespace Generation.Terrain.Procedural.GPU
             // Initializes the parameters needed for the shader
             Shader.SetFloat("height", height);
             Shader.SetFloat("squareSize", squareSize);
-            Shader.SetInt("externalSeed", new System.Random().Next());
 
             // Executes the compute shader on the GPU
             Shader.Dispatch(kernelId, numthreads, numthreads, 1);

--- a/Assets/Scripts/Generation/Terrain/Procedural/GPU/DiamondSquareShader.compute
+++ b/Assets/Scripts/Generation/Terrain/Procedural/GPU/DiamondSquareShader.compute
@@ -23,12 +23,12 @@ float normalize(uint x)
 	return 2 * (x / 4294967295.0) - 1;		// equivalent to -> f(x) = 2 * ((x - min) / (max - min)) - 1
 }
 
-float random(uint seed, uint offset)
+float random(uint range)
 {
-	return normalize(wang_hash(seed+offset));
+	return normalize(wang_hash(externalSeed + range));
 }
 
-void DiamondSquareAlgorithm(uint row, uint col, uint size, uint seed)
+void DiamondSquareAlgorithm(uint row, uint col, uint size)
 {
 	uint halfSize = (uint)(size*0.5);
 	uint mid = (row+halfSize)*(width+1) + (col+halfSize);
@@ -36,13 +36,13 @@ void DiamondSquareAlgorithm(uint row, uint col, uint size, uint seed)
 	uint bottomLeft = (row+size)*(width+1)+col;
 
 	// diamond step
-	heightmap[mid] = (heightmap[topLeft]+heightmap[topLeft+size]+heightmap[bottomLeft]+heightmap[bottomLeft+size]) * 0.25 + random(seed, mid) * height;
+	heightmap[mid] = (heightmap[topLeft]+heightmap[topLeft+size]+heightmap[bottomLeft]+heightmap[bottomLeft+size]) * 0.25 + random(mid) * height;
 
 	// square step
-	heightmap[topLeft+halfSize] = (heightmap[topLeft]+heightmap[topLeft+size]+heightmap[mid]) / 3 + random(seed, topLeft+halfSize) * height;
-	heightmap[mid-halfSize] = (heightmap[topLeft]+heightmap[bottomLeft]+heightmap[mid]) / 3 + random(seed, mid-halfSize) * height;
-	heightmap[mid+halfSize] = (heightmap[topLeft+size]+heightmap[bottomLeft+size]+heightmap[mid]) / 3 + random(seed, mid+halfSize) * height;
-	heightmap[bottomLeft+halfSize] = (heightmap[bottomLeft]+heightmap[bottomLeft+size]+heightmap[mid]) / 3 + random(seed, bottomLeft+halfSize) * height;
+	heightmap[topLeft+halfSize] = (heightmap[topLeft]+heightmap[topLeft+size]+heightmap[mid]) / 3 + random(topLeft+halfSize) * height;
+	heightmap[mid-halfSize] = (heightmap[topLeft]+heightmap[bottomLeft]+heightmap[mid]) / 3 + random(mid-halfSize) * height;
+	heightmap[mid+halfSize] = (heightmap[topLeft+size]+heightmap[bottomLeft+size]+heightmap[mid]) / 3 + random(mid+halfSize) * height;
+	heightmap[bottomLeft+halfSize] = (heightmap[bottomLeft]+heightmap[bottomLeft+size]+heightmap[mid]) / 3 + random(bottomLeft+halfSize) * height;
 }
 
 [numthreads(1,1,1)]
@@ -50,8 +50,6 @@ void CSMain (uint3 id : SV_DispatchThreadID)
 {
 	uint col = (id.x) * squareSize;
 	uint row = (id.y) * squareSize;
-	
-	uint seed = id.x + id.y + externalSeed;
 
-	DiamondSquareAlgorithm(row, col, squareSize, seed);
+	DiamondSquareAlgorithm(row, col, squareSize);
 }

--- a/Assets/Scripts/Unity/Components/DiamondSquareComponent.cs
+++ b/Assets/Scripts/Unity/Components/DiamondSquareComponent.cs
@@ -8,6 +8,7 @@ namespace Unity.Components
     [ExecuteInEditMode]
     public class DiamondSquareComponent : BaseComponent
     {
+        public string seed;
         public ComputeShader shader;
         public bool useGPU;
 
@@ -17,11 +18,12 @@ namespace Unity.Components
         {
             float[,] heightmap = base.GetTerrainHeight();
             int resolution = base.meshGenerator.resolution;
+            int intSeed = CovertStringSeedToInt(seed);
 
             if (useGPU)
-                diamondSquare = new DiamondSquareGPU(resolution, shader);
+                diamondSquare = new DiamondSquareGPU(resolution, shader, intSeed);
             else
-                diamondSquare = new DiamondSquare(resolution);
+                diamondSquare = new DiamondSquare(resolution, intSeed);
 
             TimeLogger.Start(diamondSquare.GetType().Name, diamondSquare.Resolution);
 
@@ -30,6 +32,16 @@ namespace Unity.Components
             TimeLogger.RecordSingleTimeInMilliseconds();
 
             base.UpdateTerrainHeight(heightmap);
+        }
+
+        private int CovertStringSeedToInt(string stringSeed)
+        {
+            if(string.IsNullOrWhiteSpace(stringSeed))
+                return new System.Random().Next();
+
+            var md5Hasher = System.Security.Cryptography.MD5.Create();
+            var hashed = md5Hasher.ComputeHash(System.Text.Encoding.UTF8.GetBytes(seed));
+            return System.BitConverter.ToInt32(hashed, 0);
         }
     }
 }


### PR DESCRIPTION
- There wasn't any kind of control in the terrain generated by the Diamond-Square algorithm. Therefore, it wasn't possible to replicate a previously generated terrain.
- A simple seed logic was introduced to solve this problem, where you can define a string in the Unity Editor to be the seed of the random number generator used by the Diamond-Square.
- The string is actually converted to an int using an MD5 hash before being used by the random number generator.
- Even though both `DiamondSquare` and `DiamondSquareGPU `classes share the same seed setted in the Editor, they produce different results. This occour because their methods to generate random number are not the same.