### PR TITLE
Improved Diamond-Square results by using four neighbors instead of three in the square step.

### DIFF
--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -3437,170 +3437,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 616536945}
   m_CullTransparentMesh: 0
---- !u!43 &631208761
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Mesh
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 0
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 0
-    localAABB:
-      m_Center: {x: 0, y: 0, z: 0}
-      m_Extent: {x: 0, y: 0, z: 0}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 0
-  m_KeepIndices: 0
-  m_IndexFormat: 1
-  m_IndexBuffer: 
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 0
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 0
-    _typelessdata: 
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 0, y: 0, z: 0}
-    m_Extent: {x: 0, y: 0, z: 0}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    serializedVersion: 2
-    offset: 0
-    size: 0
-    path: 
 --- !u!1 &637882162
 GameObject:
   m_ObjectHideFlags: 0
@@ -4470,7 +4306,7 @@ MeshFilter:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 740622402}
-  m_Mesh: {fileID: 631208761}
+  m_Mesh: {fileID: 1309877644}
 --- !u!1 &742329345
 GameObject:
   m_ObjectHideFlags: 0
@@ -8295,6 +8131,170 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1292036385}
   m_CullTransparentMesh: 0
+--- !u!43 &1309877644
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Mesh
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 0
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 0
+    localAABB:
+      m_Center: {x: 0, y: 0, z: 0}
+      m_Extent: {x: 0, y: 0, z: 0}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 0
+  m_KeepIndices: 0
+  m_IndexFormat: 1
+  m_IndexBuffer: 
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 0
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 0
+    _typelessdata: 
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 
 --- !u!1 &1337365873
 GameObject:
   m_ObjectHideFlags: 0
@@ -9934,7 +9934,7 @@ MonoBehaviour:
   meshGenerator: {fileID: 740622404}
   seed: test
   shader: {fileID: 7200000, guid: d9528acf6b40c4743a7f2f6c7ed57817, type: 3}
-  useGPU: 0
+  useGPU: 1
 --- !u!114 &1756491736
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -10000,7 +10000,7 @@ MonoBehaviour:
   talusFactor: 3
   iterations: 500
   shader: {fileID: 7200000, guid: d6962c6e1071c4145a3d5bfa612d40a8, type: 3}
-  useGPU: 0
+  useGPU: 1
 --- !u!114 &1756491740
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Generation/Terrain/Procedural/GPU/DiamondSquareGPU.cs
+++ b/Assets/Scripts/Generation/Terrain/Procedural/GPU/DiamondSquareGPU.cs
@@ -16,7 +16,9 @@ namespace Generation.Terrain.Procedural.GPU
 
         public override void Apply(float[,] heightmap)
         {
-            base.RandomizeCorners(heightmap);
+            base.Heightmap = heightmap;
+
+            base.RandomizeCorners();
 
             float height = 1.0f;
             int squareSize = Resolution;
@@ -24,7 +26,7 @@ namespace Generation.Terrain.Procedural.GPU
             int i = 0;
             int numthreads = 0;
 
-            int kernelId = InitComputeShader(heightmap);
+            int kernelId = InitComputeShader();
 
             while (squareSize > 1)
             {
@@ -38,19 +40,19 @@ namespace Generation.Terrain.Procedural.GPU
                 height *= 0.5f;
             }
 
-            FinishComputeShader(heightmap);
+            FinishComputeShader();
 
-            heightmap = heightmap.Normalize();
+            Heightmap = Heightmap.Normalize();
         }
 
-        private int InitComputeShader(float[,] heightmap)
+        private int InitComputeShader()
         {
             // Creates a read/writable buffer that contains the heightmap data and sends it to the GPU.
             // The buffer needs to be the same length as the heightmap, and each element in the heightmap is a single float which is 4 bytes long.
-            buffer = new ComputeBuffer(heightmap.Length, 4);
+            buffer = new ComputeBuffer(Heightmap.Length, 4);
 
             // Set the initial data to be held in the buffer as the pre-generated heightmap
-            buffer.SetData(heightmap);
+            buffer.SetData(Heightmap);
 
             int kernelId = Shader.FindKernel("CSMain");         // Gets the id of the main kernel of the shader
 
@@ -71,9 +73,9 @@ namespace Generation.Terrain.Procedural.GPU
             Shader.Dispatch(kernelId, numthreads, numthreads, 1);
         }
 
-        private void FinishComputeShader(float[,] heightmap)
+        private void FinishComputeShader()
         {
-            buffer.GetData(heightmap);          // Receive the updated heightmap data from the buffer
+            buffer.GetData(Heightmap);          // Receive the updated heightmap data from the buffer
             buffer.Dispose();                   // Dispose the buffer 
         }
     }

--- a/Assets/Scripts/Generation/Terrain/Procedural/GPU/DiamondSquareShader.compute
+++ b/Assets/Scripts/Generation/Terrain/Procedural/GPU/DiamondSquareShader.compute
@@ -28,28 +28,57 @@ float random(uint range)
 	return normalize(wang_hash(externalSeed + range));
 }
 
-void DiamondSquareAlgorithm(uint row, uint col, uint size)
+bool isInsideLimits(uint3 id)
 {
-	uint halfSize = (uint)(size*0.5);
-	uint mid = (row+halfSize)*(width+1) + (col+halfSize);
-	uint topLeft = row * (width+1)+col;
-	uint bottomLeft = (row+size)*(width+1)+col;
-
-	// diamond step
-	heightmap[mid] = (heightmap[topLeft]+heightmap[topLeft+size]+heightmap[bottomLeft]+heightmap[bottomLeft+size]) * 0.25 + random(mid) * height;
-
-	// square step
-	heightmap[topLeft+halfSize] = (heightmap[topLeft]+heightmap[topLeft+size]+heightmap[mid]) / 3 + random(topLeft+halfSize) * height;
-	heightmap[mid-halfSize] = (heightmap[topLeft]+heightmap[bottomLeft]+heightmap[mid]) / 3 + random(mid-halfSize) * height;
-	heightmap[mid+halfSize] = (heightmap[topLeft+size]+heightmap[bottomLeft+size]+heightmap[mid]) / 3 + random(mid+halfSize) * height;
-	heightmap[bottomLeft+halfSize] = (heightmap[bottomLeft]+heightmap[bottomLeft+size]+heightmap[mid]) / 3 + random(bottomLeft+halfSize) * height;
+	return id.x > 1 && id.x < width-1 && 
+		id.y > 1 && id.y < width-1;
 }
 
-[numthreads(1,1,1)]
+float getHeight(uint2 position)
+{
+	return heightmap[position.x + position.y];
+}
+
+float getHeightIfValid(uint position, uint3 id)
+{
+	return isInsideLimits(id) ? heightmap[position] : 0;
+}
+
+float average(float a, float b, float c, float d)
+{
+	return (d == 0) ? (a + b + c) / 3.0 : (a + b + c + d) * 0.25;
+}
+
+void DiamondSquareAlgorithm(uint size, uint3 id)
+{
+	uint col = id.x * squareSize;
+	uint row = id.y * squareSize;
+
+	uint halfSize = size / 2;
+
+	uint mid = (row+halfSize)*(width+1) + (col + halfSize);
+	uint topLeft = row*(width+1) + col;
+	uint topRight = row*(width+1) + (col + size);
+	uint bottomLeft = (row+size)*(width+1) + col;
+	uint bottomRight = (row+size)*(width+1) + (col + size);
+
+	// diamond step
+	heightmap[mid] = average(heightmap[topLeft], heightmap[topRight], heightmap[bottomLeft], heightmap[bottomRight]) + random(mid) * height;
+
+	uint up = topLeft + halfSize;
+	uint down = bottomLeft + halfSize;
+	uint left = mid - halfSize;
+	uint right = mid + halfSize;
+
+	// square step
+	heightmap[up] = average(heightmap[topLeft], heightmap[topRight], heightmap[mid], getHeightIfValid(up + halfSize, id)) + random(up) * height;
+	heightmap[down] = average(heightmap[bottomLeft], heightmap[bottomRight], heightmap[mid], getHeightIfValid(down - halfSize, id)) + random(down) * height;
+	heightmap[left] = average(heightmap[topLeft], heightmap[bottomLeft], heightmap[mid], getHeightIfValid(left - halfSize, id)) + random(left) * height;
+	heightmap[right] = average(heightmap[topRight], heightmap[bottomRight], heightmap[mid], getHeightIfValid(right + halfSize, id)) + random(right) * height;
+}
+
+[numthreads(1, 1, 1)]
 void CSMain (uint3 id : SV_DispatchThreadID)
 {
-	uint col = (id.x) * squareSize;
-	uint row = (id.y) * squareSize;
-
-	DiamondSquareAlgorithm(row, col, squareSize);
+	DiamondSquareAlgorithm(squareSize, id);
 }


### PR DESCRIPTION
In most cases the _Square Step_ of the _Diamond-Square_ algorithm uses four neighbors to calculate each point in the square. The only  esceptions are when the points are at the edges of the heightmap since, in these cases, there are only three neighbors.

To avoid such a problem at the edges the algorithm was using only three neighbors in all cases, regardless of whether the point is on an edge or not. This ended up causing a decrease in the _Erosion Score_ and, therefore, was fixed in this Pull Request for both CPU and GPU versions.

Before the fix, a terrain generated from the seed _"test"_ in the CPU version was scoring **0.014** in the _Erosion Score_. After the correction started to score **0.035**. 

It was difficult to measure the improvement in the GPU version since the score is not constant, but it was still possible to see some improvement.