### PR TITLE
Fixed Erosion Score calculation.

### DIFF
--- a/Assets/Scripts/Generation/Terrain/Evaluation/ErosionScore.cs
+++ b/Assets/Scripts/Generation/Terrain/Evaluation/ErosionScore.cs
@@ -24,18 +24,18 @@ namespace Generation.Terrain.Evaluation
 
             for (int x = 0; x < xSize; x++)
                 for (int y = 0; y < ySize; y++)
-                    slopemap[x, y] = GetGreatestSlopeBetweenNeighbors(new Coords(x, y), heightmap);
+                    slopemap[x, y] = GetGreatestSlopeBetweenNeighbors(x, y, heightmap);
 
             return slopemap;
         }
 
-        private static float GetGreatestSlopeBetweenNeighbors(Coords currentPosition, float[,] heightmap)
+        private static float GetGreatestSlopeBetweenNeighbors(int x, int y, float[,] heightmap)
         {
-            List<Coords> neighbors = Neighborhood.VonNeumann(currentPosition, heightmap.GetLength(0), heightmap.GetLength(1));
+            List<Coords> neighbors = Neighborhood.VonNeumann(new Coords(x, y), heightmap.GetLength(0), heightmap.GetLength(1));
             float greatestSlope = float.MinValue;
             foreach (Coords neighbor in neighbors)
             {
-                float slope = Math.Abs(heightmap[currentPosition.X, currentPosition.Y] - heightmap[neighbor.X, neighbor.Y]);
+                float slope = Math.Abs(heightmap[x, y] - heightmap[neighbor.X, neighbor.Y]);
                 if (slope > greatestSlope)
                     greatestSlope = slope;
             }
@@ -64,8 +64,8 @@ namespace Generation.Terrain.Evaluation
                 for (int y = 0; y < slopemap.GetLength(1); y++)
                     total += (slopemap[x, y] - meanValue) * (slopemap[x, y] - meanValue);
             
-            float variant = total / amount;
-            return (float) Math.Sqrt(variant);
+            float variance = total / amount;
+            return (float) Math.Sqrt(variance);
         }
     }
 }

--- a/Assets/Scripts/Generation/Terrain/Evaluation/ErosionScore.cs
+++ b/Assets/Scripts/Generation/Terrain/Evaluation/ErosionScore.cs
@@ -32,10 +32,10 @@ namespace Generation.Terrain.Evaluation
         private static float GetGreatestSlopeBetweenNeighbors(Coords currentPosition, float[,] heightmap)
         {
             List<Coords> neighbors = Neighborhood.VonNeumann(currentPosition, heightmap.GetLength(0), heightmap.GetLength(1));
-            float greatestSlope = 0.0f;
+            float greatestSlope = float.MinValue;
             foreach (Coords neighbor in neighbors)
             {
-                float slope = heightmap[currentPosition.X, currentPosition.Y] - heightmap[neighbor.X, neighbor.Y];
+                float slope = Math.Abs(heightmap[currentPosition.X, currentPosition.Y] - heightmap[neighbor.X, neighbor.Y]);
                 if (slope > greatestSlope)
                     greatestSlope = slope;
             }
@@ -62,10 +62,10 @@ namespace Generation.Terrain.Evaluation
 
             for (int x = 0; x < slopemap.GetLength(0); x++)
                 for (int y = 0; y < slopemap.GetLength(1); y++)
-                    total += slopemap[x, y] - meanValue;
+                    total += (slopemap[x, y] - meanValue) * (slopemap[x, y] - meanValue);
             
-            float totalSquared = total * total;
-            return (float) Math.Sqrt(totalSquared / amount);
+            float variant = total / amount;
+            return (float) Math.Sqrt(variant);
         }
     }
 }


### PR DESCRIPTION
The _erosion score_ calculation uses the mean and standard deviation to calculate the level of erosion of a terrain. However, the standard deviation formula had an error in which the squared value was being calculated only once at the end of the sum, instead of once for each value.

Also, when calculating the _slopemap_ the absolute value of the difference between heights wasn't being used as suppose to.

This fix brought more realistic _erosion score_ values to the _Diamond-Square_ algorithm, but it also showed that the _Thermal Erosion_ algorithm is, in fact, always decreasing the erosion score of the original terrain instead of increasing it as was supposed to do.