### PR TITLE
Added GPU version of hydraulic erosion algorithm.

### DIFF
--- a/Assets/Editor/HydraulicErosionEditor.cs
+++ b/Assets/Editor/HydraulicErosionEditor.cs
@@ -9,19 +9,22 @@ public class HydraulicErosionEditor : Editor
     private SerializedProperty rainFactor;
     private SerializedProperty solubility;
     private SerializedProperty evaporationFactor;
-    private SerializedProperty sedimentCapacity;
     private SerializedProperty iterations;
-
-    private SerializedProperty diegoli;
+    private SerializedProperty pourAndDissolveShader;
+    private SerializedProperty waterFlowShader;
+    private SerializedProperty drainWaterShader;
+    private SerializedProperty useGPU;
     
     void OnEnable()
     {
         rainFactor = serializedObject.FindProperty("rainFactor");
         solubility = serializedObject.FindProperty("solubility");
         evaporationFactor = serializedObject.FindProperty("evaporationFactor");
-        sedimentCapacity = serializedObject.FindProperty("sedimentCapacity");
         iterations = serializedObject.FindProperty("iterations");
-        diegoli = serializedObject.FindProperty("diegoli");
+        pourAndDissolveShader = serializedObject.FindProperty("pourAndDissolveShader");
+        waterFlowShader = serializedObject.FindProperty("waterFlowShader");
+        drainWaterShader = serializedObject.FindProperty("drainWaterShader");
+        useGPU = serializedObject.FindProperty("useGPU");
     }
 
     public override void OnInspectorGUI()
@@ -32,9 +35,11 @@ public class HydraulicErosionEditor : Editor
         EditorGUILayout.PropertyField(rainFactor);
         EditorGUILayout.PropertyField(solubility);
         EditorGUILayout.PropertyField(evaporationFactor);
-        EditorGUILayout.PropertyField(sedimentCapacity);
         EditorGUILayout.PropertyField(iterations);
-        EditorGUILayout.PropertyField(diegoli);
+        EditorGUILayout.PropertyField(pourAndDissolveShader);
+        EditorGUILayout.PropertyField(waterFlowShader);
+        EditorGUILayout.PropertyField(drainWaterShader);
+        EditorGUILayout.PropertyField(useGPU);
         
         if (GUILayout.Button("Apply"))
             component.UpdateComponent();

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -4366,7 +4366,7 @@ MeshFilter:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 740622402}
-  m_Mesh: {fileID: 1644522616}
+  m_Mesh: {fileID: 1228830296}
 --- !u!1 &742329345
 GameObject:
   m_ObjectHideFlags: 0
@@ -7774,6 +7774,170 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1214653348}
   m_CullTransparentMesh: 0
+--- !u!43 &1228830296
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Mesh
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 0
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 0
+    localAABB:
+      m_Center: {x: 0, y: 0, z: 0}
+      m_Extent: {x: 0, y: 0, z: 0}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 0
+  m_KeepIndices: 0
+  m_IndexFormat: 1
+  m_IndexBuffer: 
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 0
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 0
+    _typelessdata: 
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 
 --- !u!1 &1244415758
 GameObject:
   m_ObjectHideFlags: 0
@@ -9615,170 +9779,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1643222673}
   m_CullTransparentMesh: 0
---- !u!43 &1644522616
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Mesh
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 0
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 0
-    localAABB:
-      m_Center: {x: 0, y: 0, z: 0}
-      m_Extent: {x: 0, y: 0, z: 0}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 0
-  m_KeepIndices: 0
-  m_IndexFormat: 1
-  m_IndexBuffer: 
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 0
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 0
-    _typelessdata: 
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 0, y: 0, z: 0}
-    m_Extent: {x: 0, y: 0, z: 0}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    serializedVersion: 2
-    offset: 0
-    size: 0
-    path: 
 --- !u!1 &1714994003
 GameObject:
   m_ObjectHideFlags: 0
@@ -9993,10 +9993,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   meshGenerator: {fileID: 740622404}
-  randomGeneration: 1
-  seed: 647462703
+  randomGeneration: 0
+  seed: 1811588772
   shader: {fileID: 7200000, guid: d9528acf6b40c4743a7f2f6c7ed57817, type: 3}
-  useGPU: 0
+  useGPU: 1
   onlyBestResults: 0
   tries: 500
   minimumFirstValue: 28
@@ -10062,7 +10062,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   meshGenerator: {fileID: 740622404}
   factor: 0.5
-  talusFactor: 2
+  talusFactor: 6
   iterations: 100
   shader: {fileID: 7200000, guid: d6962c6e1071c4145a3d5bfa612d40a8, type: 3}
   useGPU: 1
@@ -10079,12 +10079,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   meshGenerator: {fileID: 740622404}
-  rainFactor: 0.01
-  solubility: 0.01
+  rainFactor: 0.08
+  solubility: 0.02
   evaporationFactor: 0.5
-  sedimentCapacity: 0.01
-  iterations: 50
-  diegoli: 1
+  iterations: 100
+  pourAndDissolveShader: {fileID: 7200000, guid: 225314a3bc72fb642b43f050a7592482,
+    type: 3}
+  waterFlowShader: {fileID: 7200000, guid: 087ac59dc8357e04d814e039ec49a460, type: 3}
+  drainWaterShader: {fileID: 7200000, guid: 5875bea7e56245f4e82d1d2b0c3cccc1, type: 3}
+  useGPU: 0
 --- !u!114 &1756491741
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Generation/Terrain/Physics/HydraulicErosion.meta
+++ b/Assets/Scripts/Generation/Terrain/Physics/HydraulicErosion.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dd8cb6647e2c5284f911b0fec81e391b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Generation/Terrain/Physics/HydraulicErosion/DrainWaterShader.compute
+++ b/Assets/Scripts/Generation/Terrain/Physics/HydraulicErosion/DrainWaterShader.compute
@@ -1,0 +1,29 @@
+﻿#pragma kernel CSMain
+
+RWStructuredBuffer<float> heightmap;
+RWStructuredBuffer<float> watermap;
+
+float evaporationFactor;
+float solubility;
+
+uint width;
+
+[numthreads(25, 25, 1)]
+void CSMain (uint3 id : SV_DispatchThreadID)
+{
+	uint currentPosition = id.x + (id.y * width);
+
+    if (evaporationFactor == 0)
+        return;
+
+    float evaporationPercent = 1 - evaporationFactor;
+    float waterVolume = watermap[currentPosition] - heightmap[currentPosition];
+
+    if (waterVolume <= 0) 
+        return;
+
+    float delta = waterVolume - (waterVolume * evaporationPercent);
+    
+    watermap[currentPosition] = max(0, watermap[currentPosition] - delta);
+    heightmap[currentPosition] = min(1, heightmap[currentPosition] + (solubility * delta));
+}

--- a/Assets/Scripts/Generation/Terrain/Physics/HydraulicErosion/DrainWaterShader.compute.meta
+++ b/Assets/Scripts/Generation/Terrain/Physics/HydraulicErosion/DrainWaterShader.compute.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5875bea7e56245f4e82d1d2b0c3cccc1
+ComputeShaderImporter:
+  externalObjects: {}
+  currentAPIMask: 4
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Generation/Terrain/Physics/HydraulicErosion/HydraulicErosionGPU.cs
+++ b/Assets/Scripts/Generation/Terrain/Physics/HydraulicErosion/HydraulicErosionGPU.cs
@@ -1,0 +1,98 @@
+﻿using UnityEngine;
+
+namespace Generation.Terrain.Physics.Erosion.GPU
+{
+    public class HydraulicErosionGPU : HydraulicErosionDiegoli
+    {
+        public ComputeShader PourAndDissolveShader { get; set; }
+        public ComputeShader WaterFlowShader { get; set; }
+        public ComputeShader DrainWaterShader { get; set; }
+
+        private ComputeBuffer heightmapBuffer;
+        private ComputeBuffer watermapBuffer;
+
+        private const int threadGroupsX = 41;
+        private const int threadGroupsY = 41;
+        
+        public HydraulicErosionGPU(ComputeShader pourAndDissolveShader, ComputeShader waterFlowShader, ComputeShader drainWaterShader) : base()
+        {
+            PourAndDissolveShader = pourAndDissolveShader;
+            WaterFlowShader = waterFlowShader;
+            DrainWaterShader = drainWaterShader;
+        }
+
+        public override void Erode(float[,] heightmap, float rainFactor, float solubility, float evaporationFactor, int iterations)
+        {
+            float[,] watermap = heightmap.Clone() as float[,];
+            int width = heightmap.GetLength(0);
+
+            heightmapBuffer = new ComputeBuffer(heightmap.Length, 4);
+            watermapBuffer = new ComputeBuffer(watermap.Length, 4);
+            
+            heightmapBuffer.SetData(heightmap);
+            watermapBuffer.SetData(watermap);
+
+            int pourAndDissolveId = InitPourAndDissolveShader(rainFactor, solubility, width);
+            int waterFlowId = InitWaterFlowShader(width);
+            int drainWaterId = InitDrainWaterShader(evaporationFactor, solubility, width);
+
+            for (int i = 0; i < iterations; i++)
+                RunComputeShaders(pourAndDissolveId, waterFlowId, drainWaterId);
+        
+            FinishComputeShaders(heightmap, watermap);
+        }
+
+        private int InitPourAndDissolveShader(float rainFactor, float solubility, int width)
+        {
+            int kernelId = PourAndDissolveShader.FindKernel("CSMain");
+            
+            PourAndDissolveShader.SetBuffer(kernelId, "heightmap", heightmapBuffer);
+            PourAndDissolveShader.SetBuffer(kernelId, "watermap", watermapBuffer);
+            PourAndDissolveShader.SetFloat("rainFactor", rainFactor);
+            PourAndDissolveShader.SetFloat("solubility", solubility);
+            PourAndDissolveShader.SetInt("width", width);
+
+            return kernelId;
+        }
+
+        private int InitWaterFlowShader(int width)
+        {
+            int kernelId = WaterFlowShader.FindKernel("CSMain");
+            
+            WaterFlowShader.SetBuffer(kernelId, "heightmap", heightmapBuffer);
+            WaterFlowShader.SetBuffer(kernelId, "watermap", watermapBuffer);
+            WaterFlowShader.SetInt("width", width);
+
+            return kernelId;
+        }
+
+        private int InitDrainWaterShader(float evaporationFactor, float solubility, int width)
+        {
+            int kernelId = DrainWaterShader.FindKernel("CSMain");
+            
+            DrainWaterShader.SetBuffer(kernelId, "heightmap", heightmapBuffer);
+            DrainWaterShader.SetBuffer(kernelId, "watermap", watermapBuffer);
+            DrainWaterShader.SetFloat("evaporationFactor", evaporationFactor);
+            DrainWaterShader.SetFloat("solubility", solubility);
+            DrainWaterShader.SetInt("width", width);
+
+            return kernelId;
+        }
+
+        private void RunComputeShaders(int pourAndDissolveId, int waterFlowId, int drainWaterId)
+        {
+            PourAndDissolveShader.Dispatch(pourAndDissolveId, threadGroupsX, threadGroupsY, 1);
+            WaterFlowShader.Dispatch(waterFlowId, threadGroupsX, threadGroupsY, 1);
+            DrainWaterShader.Dispatch(drainWaterId, threadGroupsX, threadGroupsY, 1);
+        }
+
+        private void FinishComputeShaders(float[,] heightmap, float[,] watermap)
+        {
+            heightmapBuffer.GetData(heightmap);
+            heightmapBuffer.Dispose();
+            
+            watermapBuffer.GetData(watermap);
+            watermapBuffer.Dispose();
+        }
+    }
+}

--- a/Assets/Scripts/Generation/Terrain/Physics/HydraulicErosion/HydraulicErosionGPU.cs.meta
+++ b/Assets/Scripts/Generation/Terrain/Physics/HydraulicErosion/HydraulicErosionGPU.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 541e4af5f5f4d9549ae05b68575c5c6e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Generation/Terrain/Physics/HydraulicErosion/PourAndDissolveShader.compute
+++ b/Assets/Scripts/Generation/Terrain/Physics/HydraulicErosion/PourAndDissolveShader.compute
@@ -1,0 +1,29 @@
+﻿#pragma kernel CSMain
+
+RWStructuredBuffer<float> heightmap;
+RWStructuredBuffer<float> watermap;
+
+float rainFactor;
+float solubility;
+uint width;
+
+[numthreads(25, 25, 1)]
+void CSMain (uint3 id : SV_DispatchThreadID)
+{
+	uint currentPosition = id.x + (id.y * width);
+
+    // Pour Water
+    watermap[currentPosition] += rainFactor;
+    
+    // Dissolve    
+    if(solubility <= 0)
+        return;
+
+    float waterVolume = watermap[currentPosition] - heightmap[currentPosition];
+    if (waterVolume <= 0)
+        return;
+
+    float amountToRemove = solubility * waterVolume;
+    heightmap[currentPosition] -= amountToRemove;
+    heightmap[currentPosition] = max(0, heightmap[currentPosition]);
+}

--- a/Assets/Scripts/Generation/Terrain/Physics/HydraulicErosion/PourAndDissolveShader.compute.meta
+++ b/Assets/Scripts/Generation/Terrain/Physics/HydraulicErosion/PourAndDissolveShader.compute.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 225314a3bc72fb642b43f050a7592482
+ComputeShaderImporter:
+  externalObjects: {}
+  currentAPIMask: 4
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Generation/Terrain/Physics/HydraulicErosion/WaterFlowShader.compute
+++ b/Assets/Scripts/Generation/Terrain/Physics/HydraulicErosion/WaterFlowShader.compute
@@ -1,0 +1,97 @@
+﻿#pragma kernel CSMain
+
+#define UP 0
+#define DOWN 1
+#define LEFT 2
+#define RIGHT 3
+// #define LEFT_UP 4
+// #define RIGHT_UP 5
+// #define LEFT_DOWN 6
+// #define RIGHT_DOWN 7
+
+#define NEIGHBORHOOD_SIZE 4
+
+RWStructuredBuffer<float> heightmap;
+RWStructuredBuffer<float> watermap;
+
+uint width;
+
+uint neighbors[NEIGHBORHOOD_SIZE];
+
+void GetNeighbors(uint currentPosition)
+{
+	neighbors[UP] = currentPosition - width;
+	neighbors[DOWN] = currentPosition + width;
+	neighbors[LEFT] = currentPosition - 1;
+	neighbors[RIGHT] = currentPosition + 1;
+	// neighbors[LEFT_UP] = (currentPosition - 1) - width;
+	// neighbors[RIGHT_UP] = (currentPosition + 1) - width;
+	// neighbors[LEFT_DOWN] = (currentPosition - 1) + width;
+	// neighbors[RIGHT_DOWN] = (currentPosition + 1) + width;
+}
+
+int isValidPosition(uint3 id)
+{
+	return id.x > 1 && id.x < width-1 && 
+			id.y > 1 && id.y < width-1;
+}
+
+[numthreads(25, 25, 1)]
+void CSMain (uint3 id : SV_DispatchThreadID)
+{
+	uint currentPosition = id.x + (id.y * width);
+
+    if(!isValidPosition(id))
+        return;
+
+    GetNeighbors(currentPosition);
+
+    float localSurfaceHeight = watermap[currentPosition];
+    float localWaterVolume = localSurfaceHeight - heightmap[currentPosition];
+
+    if (localWaterVolume < 0)
+        return;
+
+    float avgSurfaceHeight = 0;
+    int countHeights = 0;
+    float totalDifference = 0;
+
+    for(uint i = 0; i < NEIGHBORHOOD_SIZE; i++)
+    {
+        float nearbySurfaceHeight = watermap[neighbors[i]];
+        float difference = localSurfaceHeight - nearbySurfaceHeight;
+        
+        if (difference < 0)
+            continue;
+
+        totalDifference += difference;
+        avgSurfaceHeight += nearbySurfaceHeight;
+        countHeights++;
+    }
+
+    if (totalDifference == 0)
+        return;
+
+    avgSurfaceHeight /= countHeights;
+
+    float deltaSurfaceHeight = localSurfaceHeight - avgSurfaceHeight;
+
+    float totalDeltaWater = 0;
+
+    for(i = 0; i < NEIGHBORHOOD_SIZE; i++)
+    {
+        float nearbySurfaceHeight = watermap[neighbors[i]];
+        
+        if (nearbySurfaceHeight >= localSurfaceHeight) 
+            continue;
+        
+        float difference = localSurfaceHeight - nearbySurfaceHeight;
+        float deltaWater = min(localWaterVolume, deltaSurfaceHeight) * (difference / totalDifference);
+
+        watermap[neighbors[i]] += deltaWater;
+        totalDeltaWater += deltaWater;
+    }
+
+    if (totalDeltaWater > 0)
+        watermap[currentPosition] -= totalDeltaWater;
+}

--- a/Assets/Scripts/Generation/Terrain/Physics/HydraulicErosion/WaterFlowShader.compute.meta
+++ b/Assets/Scripts/Generation/Terrain/Physics/HydraulicErosion/WaterFlowShader.compute.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 087ac59dc8357e04d814e039ec49a460
+ComputeShaderImporter:
+  externalObjects: {}
+  currentAPIMask: 4
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Generation/Terrain/Physics/HydraulicErosionDiegoliOptimized.cs
+++ b/Assets/Scripts/Generation/Terrain/Physics/HydraulicErosionDiegoliOptimized.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.Collections.Generic;
+using Generation.Terrain.Utils;
+
+namespace Generation.Terrain.Physics.Erosion
+{
+    public class HydraulicErosionDiegoliOptimized : HydraulicErosionDiegoli
+    {
+        public override void Erode(float[,] heightmap, float pour, float solubility, float evaporationFactor, int iterations)
+        {
+            float[,] water = heightmap.Clone() as float[,];
+
+            for (int i = 0; i < iterations; i++)
+                Erode(heightmap, water, pour, solubility, evaporationFactor);
+        }
+
+        public override  void Erode(float[,] heightmap, float[,] water, float rainFactor, float solubility, float evaporationFactor)
+        {
+            PourWaterAndDissolve(heightmap, water, rainFactor, solubility);
+            WaterFlow(heightmap, water);
+            DrainWater(heightmap, water, solubility, evaporationFactor);
+        }
+
+        private void PourWaterAndDissolve(float[,] heightmap, float[,] water, float rainFactor, float solubility)
+        {
+            for (int x = 0; x < heightmap.GetLength(0); x++)
+            {
+                for (int y = 0; y < heightmap.GetLength(1); y++)
+                {
+                    // Pour Water
+                    water[x, y] += rainFactor;
+                    
+                    // Dissolve
+                    if(solubility <= 0f)
+                        continue;
+                    
+                    float waterVolume = water[x, y] - heightmap[x, y];
+                    if (waterVolume <= 0)
+                        continue;
+
+                    float amountToRemove = solubility * waterVolume;
+                    heightmap[x, y] -= amountToRemove;
+                    heightmap[x, y] = Math.Max(0f, heightmap[x, y]);
+                }
+            }
+        }
+
+        private void WaterFlow(float[,] heightmap, float[,] water)
+        {
+            int maxX = heightmap.GetLength(0);
+            int maxY = heightmap.GetLength(1);
+            for (int x = 0; x < maxX; x++)
+            {
+                for (int y = 0; y < maxY; y++)
+                {
+                    float localSurfaceHeight = water[x, y];
+                    float localWaterVolume = localSurfaceHeight - heightmap[x, y];
+
+                    if (localWaterVolume < 0)
+                        continue;
+
+                    float avgSurfaceHeight = 0;
+                    int countHeights = 0;
+                    float totalDifference = 0;
+
+                    List<Coords> neighbors = Neighborhood.VonNeumann(new Coords(x, y), maxX, maxY);
+
+                    foreach (var neighbor in neighbors)
+                    {
+                        float nearbySurfaceHeight = water[neighbor.X, neighbor.Y];
+                        float difference = localSurfaceHeight - nearbySurfaceHeight;
+                        
+                        if (difference < 0)
+                            continue;
+
+                        totalDifference += difference;
+                        avgSurfaceHeight += nearbySurfaceHeight;
+                        countHeights++;
+                    }
+
+                    if (totalDifference == 0)
+                        continue;
+
+                    avgSurfaceHeight /= countHeights;
+
+                    float deltaSurfaceHeight = localSurfaceHeight - avgSurfaceHeight;
+
+                    float totalDeltaWater = 0;
+
+                    foreach (var neighbor in neighbors)
+                    {
+                        float nearbySurfaceHeight = water[neighbor.X, neighbor.Y];
+                        
+                        if (nearbySurfaceHeight >= localSurfaceHeight) 
+                            continue;
+                        
+                        float difference = localSurfaceHeight - nearbySurfaceHeight;
+                        float deltaWater = Math.Min(localWaterVolume, deltaSurfaceHeight) * (difference / totalDifference);
+
+                        water[neighbor.X, neighbor.Y] += deltaWater;
+                        totalDeltaWater += deltaWater;
+                    }
+
+                    if (totalDeltaWater > 0)
+                        water[x, y] -= totalDeltaWater;
+                }
+            }
+        }
+
+        private void DrainWater(float[,] heightmap, float[,] water, float solubility, float evaporationFactor)
+        {
+            if (evaporationFactor == 0)
+                return;
+
+            float evaporationPercent = (1f - evaporationFactor);
+
+            for (int x = 0; x < heightmap.GetLength(0); x++)
+            {
+                for (int y = 0; y < heightmap.GetLength(1); y++)
+                {
+                    float waterVolume = water[x, y] - heightmap[x, y];
+
+                    if (waterVolume <= 0) 
+                        continue;
+
+                    float delta = waterVolume - (waterVolume * evaporationPercent);
+                    water[x, y] -= delta;
+                    heightmap[x, y] += solubility * delta;
+                    heightmap[x, y] = Math.Min(1f, heightmap[x, y]);
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Generation/Terrain/Physics/HydraulicErosionDiegoliOptimized.cs.meta
+++ b/Assets/Scripts/Generation/Terrain/Physics/HydraulicErosionDiegoliOptimized.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9afbea6ebc78a9045bd0ee087e577ef1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Generation/Terrain/Physics/ThermalErosionGPU.cs
+++ b/Assets/Scripts/Generation/Terrain/Physics/ThermalErosionGPU.cs
@@ -13,6 +13,16 @@ namespace Generation.Terrain.Physics.Erosion.GPU
             Shader = shader;
         }
 
+        public override void Erode(float[,] heightmap, float talus = 4, float factor = 0.5f, int iterations = 500)
+        {
+            int kernelId = InitComputeShader(heightmap, talus, factor);
+
+            for (int i = 0; i < iterations; i++)
+                RunComputeShader(kernelId);
+        
+            FinishComputeShader(heightmap);
+        }
+
         private int InitComputeShader(float[,] heightmap, float talus, float factor)
         {
             // Creates a read/writable buffer that contains the heightmap data and sends it to the GPU.
@@ -30,16 +40,6 @@ namespace Generation.Terrain.Physics.Erosion.GPU
             Shader.SetInt("width", heightmap.GetLength(0));
 
             return kernelId;
-        }
-
-        public override void Erode(float[,] heightmap, float talus = 4, float factor = 0.5f, int iterations = 500)
-        {
-            int kernelId = InitComputeShader(heightmap, talus, factor);
-
-            for (int i = 0; i < iterations; i++)
-                RunComputeShader(kernelId);
-        
-            FinishComputeShader(heightmap);
         }
 
         private void RunComputeShader(int kernelId)

--- a/Assets/Scripts/Unity/Components/DiamondSquareComponent.cs
+++ b/Assets/Scripts/Unity/Components/DiamondSquareComponent.cs
@@ -60,10 +60,9 @@ namespace Unity.Components
             string erosionScore = ErosionScore.Evaluate(heightmap).ToString();
             string benfordsLaw = BenfordsLaw.Evaluate(heightmap);
 
-            Debug.Log($"Erosion Score Diamond-Square: {erosionScore}");
-            Debug.Log($"Benford's Law Diamond-Square: {benfordsLaw}");
-            EvaluationLogger.RecordValue("erosion_score", heightmap.GetLength(0), seed, erosionScore);
-            EvaluationLogger.RecordValue("benfords_law", heightmap.GetLength(0), seed, benfordsLaw);
+            Debug.Log($"Diamond-Square: {erosionScore} -> {benfordsLaw}");
+            // EvaluationLogger.RecordValue("erosion_score", heightmap.GetLength(0), seed, erosionScore);
+            // EvaluationLogger.RecordValue("benfords_law", heightmap.GetLength(0), seed, benfordsLaw);
 
             base.UpdateTerrainHeight(heightmap);
         }

--- a/Assets/Scripts/Unity/Components/ThermalErosionComponent.cs
+++ b/Assets/Scripts/Unity/Components/ThermalErosionComponent.cs
@@ -34,8 +34,13 @@ namespace Unity.Components
             thermalErosion.Erode(heightmap, talus, factor, iterations);
             TimeLogger.RecordSingleTimeInMilliseconds();
 
-            Debug.Log($"Erosion Score Thermal Erosion: {ErosionScore.Evaluate(heightmap)}");
-            Debug.Log($"Benford's Law Thermal Erosion: {BenfordsLaw.Evaluate(heightmap)}");
+            int seed = FindObjectOfType<DiamondSquareComponent>().seed;
+            string erosionScore = ErosionScore.Evaluate(heightmap).ToString();
+            string benfordsLaw = BenfordsLaw.Evaluate(heightmap);
+            
+            Debug.Log($"Thermal Erosion: {erosionScore} -> {benfordsLaw}");
+            EvaluationLogger.RecordValue("erosion_score", heightmap.GetLength(0), seed, erosionScore);
+            EvaluationLogger.RecordValue("benfords_law", heightmap.GetLength(0), seed, benfordsLaw);
 
             UpdateTerrainHeight(heightmap);
         }


### PR DESCRIPTION
- Added shaders `PourAndDissolveShader.compute`, `WaterFlowShader.compute` e `DrainWaterShader.compute` which are responsible for the hydraulic erosion simulation. It was not possible to simulate the whole process in a single shader as with the thermal erosion algorithm;
- Added `HydraulicErosionGPU.cs` to orquestrate and run the three shaders;
- Added `HydraulicErosionDiegoliOptimized.cs` used as base for the GPU version.